### PR TITLE
✨ Add a new IP checker script using ipintel

### DIFF
--- a/scripts/Main.as
+++ b/scripts/Main.as
@@ -5,6 +5,7 @@
 #include "streamValidation.as"
 #include "botAPI.as"
 #include "kickNotificationWrapper.as"
+#include "ipChecker.as"
 
 // Create a chatManager object instance
 chatManager chatSystem();
@@ -114,6 +115,11 @@ array<string>  streamFilterList =
 	"foo.truck","bar.truck"
 }; 
 //streamValidation bannedCars(@streamFilterList, BLACKLIST);
+
+// Remove the // in front of the next line to enable the IP checker system.
+// Make sure to set your email address in ipChecker.as, otherwise this won't work
+// we don't have a config file for scripts yet, sooo... yeah
+// ipChecker ip("mysupersecret@notvalid.com");
 
 
 // Our main function (never remove this, even when it does nothing useful!)

--- a/scripts/includes/ipChecker.as
+++ b/scripts/includes/ipChecker.as
@@ -1,0 +1,90 @@
+class ipChecker
+{
+	dictionary playerQueue; // maps displayname -> uid
+    private string contactEmail = "";
+
+	ipChecker(const string &in contactEmail_ = "")
+	{
+        if (contactEmail_ != "")
+		{
+			// Set the contact email for the IP checker
+			this.contactEmail = contactEmail_;
+		}
+        else
+        {
+            // If you enabled this, please set your email address in Main.as.
+            server.throwException("ipChecker exception: No contact email provided. Please provide a valid email address.");
+        }
+		server.setCallback("playerAdded", "playerAdded", @this);
+		server.setCallback("curlStatus",  "curlStatus",  @this);
+	}
+
+    ~ipChecker()
+    {
+        destroy();
+    }
+    
+    void destroy()
+    {
+        server.deleteCallback("playerAdded", "playerAdded", @this);
+        server.deleteCallback("curlStatus",  "curlStatus",  @this);
+    }
+
+
+	void playerAdded(int uid)
+	{
+		string ip = server.getUserIPAddress(uid);
+        // string ip = "144.217.84.5"; // Test IP, known VPN/Proxy
+		if(ip == "")
+            // huh??!
+			return;
+
+        // Create a unique displayname for this request
+		string displayname = "ipchecker_" + uid;
+		playerQueue.set(displayname, uid);
+
+		string url = "https://check.getipintel.net/check.php?ip=" + ip +
+		             "&contact=" + contactEmail;
+
+		server.Log("ipChecker: Checking IP for UID " + uid + ": " + ip);
+		server.curlRequestAsync(url, displayname);
+	}
+
+	void curlStatus(curlStatusType type, int n1, int n2, string displayname, string message)
+	{
+		if(!playerQueue.exists(displayname))
+			return; // not our request
+
+		int uid;
+        // we're doing the request, get the uid and remove from list
+		playerQueue.get(displayname, uid);
+		playerQueue.delete(displayname);
+
+        if (type == CURL_STATUS_FAILURE)
+        {
+            server.Log("ipChecker: Request failed for UID: " + uid);
+            server.Log("ipChecker:      Error message: " + message);
+            server.Log("ipChecker:      cURL code: " + n1);
+            server.Log("ipChecker:      HTTP code: " + n2);
+            return;
+        }
+
+        if (type == CURL_STATUS_SUCCESS)
+        {
+            // message contains the response
+            // A response of -1 means the IP is invalid, -2 means it's an internal error,
+            // > .95 means it's a VPN or Proxy, < .95 means it's probably not.
+            // See https://getipintel.net/#check for details.
+            float score = parseFloat(message);
+
+            server.Log("ipChecker: UID " + uid + " confidence score: " + formatFloat(score, "", 0, 2));
+
+            if(score > 0.95f)
+            {
+                server.say("Player " + server.getUserName(uid) + " (" + uid + 
+                        ") appears to be using a VPN/Proxy. Kicking...", uid, FROM_SERVER);
+                server.kick(uid, "VPN/Proxy detected, confidence score (" + formatFloat(score, "", 0, 2) + ")");
+            }
+        }
+	}
+}


### PR DESCRIPTION
RoR server has very weak counter measures to preventing abuse, see https://github.com/RigsOfRods/ror-server/issues/168

Since https://github.com/RigsOfRods/ror-server/commit/6f054acf11320a92eadc4c904102567652667ea1 brings curl support into scripting, we can now use external API to verify if a player's IP address is a VPN/proxy.

To test this, go into Main.as and uncomment the ipChecker with a VALID email. Localhost will FAIL (returns a error 400). Ideally have the client on a different machine on an external connection.